### PR TITLE
feat: add netlify identity and neon integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ This repo can be forked and cloned from https://github.com/CDelancy19/Stackathon
 After cloning to your machine run `npm install` to install needed dependencies.
 The app now uses SQLite for storage by default, so no PostgreSQL configuration is required.
 Running `npm run start:dev` will both start your server and build your client side files using webpack. After running, the app will immediately scrape for current tournaments.
+
+## Netlify Identity and Neon
+
+Sample Netlify Functions have been added under `netlify/functions` to illustrate how to use Netlify Identity JWTs with a Neon (Postgres) database. Provide a `DATABASE_URL` environment variable and the functions can store and retrieve favorited players and match subscriptions for authenticated users.

--- a/client/index.js
+++ b/client/index.js
@@ -6,10 +6,13 @@ import history from './history';
 import store from './store';
 import App from './App';
 // import 'bootstrap/dist/css/bootstrap.min.css';
+import netlifyIdentity from 'netlify-identity-widget';
+
+netlifyIdentity.init();
 
 ReactDOM.render(
-	<Provider store={store}>
-		<Router history={history}>
+        <Provider store={store}>
+                <Router history={history}>
 			<App />
 		</Router>
 	</Provider>,

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,5 @@
 [build]
   command = "npm run build"
   publish = "public"
+  functions = "netlify/functions"
 

--- a/netlify/functions/add-favorite.js
+++ b/netlify/functions/add-favorite.js
@@ -1,0 +1,26 @@
+const jwt = require('jsonwebtoken');
+const { query } = require('./db');
+
+exports.handler = async (event) => {
+  try {
+    const token = event.headers.authorization?.split(' ')[1];
+    const user = jwt.decode(token);
+    const { playerId } = JSON.parse(event.body);
+
+    await query(
+      'INSERT INTO user_favorites (user_id, player_id) VALUES ($1, $2) ON CONFLICT DO NOTHING',
+      [user.sub, playerId]
+    );
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ success: true }),
+    };
+  } catch (err) {
+    return {
+      statusCode: 500,
+      body: err.message,
+    };
+  }
+};
+

--- a/netlify/functions/db.js
+++ b/netlify/functions/db.js
@@ -1,0 +1,16 @@
+const { Pool } = require('@neondatabase/serverless');
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+async function query(text, params) {
+  const client = await pool.connect();
+  try {
+    const res = await client.query(text, params);
+    return res.rows;
+  } finally {
+    client.release();
+  }
+}
+
+module.exports = { query };
+

--- a/netlify/functions/get-favorites.js
+++ b/netlify/functions/get-favorites.js
@@ -1,0 +1,25 @@
+const jwt = require('jsonwebtoken');
+const { query } = require('./db');
+
+exports.handler = async (event) => {
+  try {
+    const token = event.headers.authorization?.split(' ')[1];
+    const user = jwt.decode(token);
+
+    const favorites = await query(
+      'SELECT p.* FROM user_favorites uf JOIN players p ON uf.player_id = p.id WHERE uf.user_id = $1',
+      [user.sub]
+    );
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify(favorites),
+    };
+  } catch (err) {
+    return {
+      statusCode: 500,
+      body: err.message,
+    };
+  }
+};
+

--- a/netlify/functions/subscribe-match.js
+++ b/netlify/functions/subscribe-match.js
@@ -1,0 +1,26 @@
+const jwt = require('jsonwebtoken');
+const { query } = require('./db');
+
+exports.handler = async (event) => {
+  try {
+    const token = event.headers.authorization?.split(' ')[1];
+    const user = jwt.decode(token);
+    const { matchId } = JSON.parse(event.body);
+
+    await query(
+      'INSERT INTO user_subscriptions (user_id, match_id) VALUES ($1, $2) ON CONFLICT DO NOTHING',
+      [user.sub, matchId]
+    );
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ success: true }),
+    };
+  } catch (err) {
+    return {
+      statusCode: 500,
+      body: err.message,
+    };
+  }
+};
+

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "Fullstack Academy of Code",
   "license": "MIT",
   "dependencies": {
+    "@neondatabase/serverless": "^1.0.1",
     "bcrypt": "^5.0.0",
     "bootstrap": "^5.1.3",
     "compression": "^1.7.3",
@@ -33,6 +34,7 @@
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.21",
     "morgan": "^1.9.1",
+    "netlify-identity-widget": "^1.9.2",
     "nightmare": "^3.0.2",
     "pg": "^8.5.1",
     "react-bootstrap": "^2.1.0",

--- a/public/index.html
+++ b/public/index.html
@@ -10,15 +10,16 @@
 			integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
 			crossorigin="anonymous"
 		/>
-		<link rel="stylesheet" href="/style.css" />
-		<!-- <link
-			rel="stylesheet"
-			href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css"
-			integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk"
-			crossorigin="anonymous"
-		/> -->
-		<script defer src="/bundle.js"></script>
-	</head>
+                <link rel="stylesheet" href="/style.css" />
+                <!-- <link
+                        rel="stylesheet"
+                        href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css"
+                        integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk"
+                        crossorigin="anonymous"
+                /> -->
+                <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
+                <script defer src="/bundle.js"></script>
+        </head>
 	<body>
 		<div id="app"></div>
 		<script


### PR DESCRIPTION
## Summary
- add Netlify Identity widget and initialization in client
- configure Netlify Functions for Neon Postgres and add favorite/subscription handlers

## Testing
- `npm test` *(fails: Please install sqlite3 package manually)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c31b6194832f9c7c742e5534fdd4