### PR TITLE
Add RapidAPI tennis search endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ yarn-error.log
 package-lock.json
 
 server/db/*.sqlite
+.env

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ After cloning to your machine run `npm install` to install needed dependencies.
 The app now uses SQLite for storage by default, so no PostgreSQL configuration is required.
 Running `npm run start:dev` will both start your server and build your client side files using webpack. After running, the app will immediately scrape for current tournaments.
 
+### RapidAPI Tennis Search
+
+The server exposes a proxy endpoint to the [Tennis API – ATP WTA ITF](https://rapidapi.com/). Set your RapidAPI key in the environment variable `RAPIDAPI_KEY` before starting the server:
+
+```bash
+RAPIDAPI_KEY=your_key npm start
+```
+
+Then you can query the API via `/api/tennis/search?q=player` to search for players or tournaments. The key is read from `process.env` so it stays out of version control.
+
 ## Netlify Identity and Neon
 
 Sample Netlify Functions have been added under `netlify/functions` to illustrate how to use Netlify Identity JWTs with a Neon (Postgres) database. Provide a `DATABASE_URL` environment variable and the functions can store and retrieve favorited players and match subscriptions for authenticated users.

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -3,6 +3,7 @@ module.exports = router
 
 router.use('/users', require('./users'))
 router.use('/matches', require('./matches'))
+router.use('/tennis', require('./tennis'))
 
 router.use((req, res, next) => {
   const error = new Error('Not Found')

--- a/server/api/tennis.js
+++ b/server/api/tennis.js
@@ -1,0 +1,25 @@
+const router = require('express').Router()
+const axios = require('axios')
+
+// Search tennis data via RapidAPI
+router.get('/search', async (req, res, next) => {
+  try {
+    const { q } = req.query
+    const options = {
+      method: 'GET',
+      url: 'https://tennis-api-atp-wta-itf.p.rapidapi.com/tennis/v2/search',
+      params: { search: q || 'ABC' },
+      headers: {
+        'x-rapidapi-key': process.env.RAPIDAPI_KEY,
+        'x-rapidapi-host': 'tennis-api-atp-wta-itf.p.rapidapi.com',
+      },
+    }
+
+    const { data } = await axios.request(options)
+    res.json(data)
+  } catch (err) {
+    next(err)
+  }
+})
+
+module.exports = router


### PR DESCRIPTION
## Summary
- add `/api/tennis/search` route that proxies RapidAPI Tennis API using an env var key
- document RAPIDAPI_KEY setup and usage
- ignore `.env` to keep secrets out of version control

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1d0765fc8832fbd2f126fcd4943d2