### PR TITLE
Add fallback when tennis API data is missing

### DIFF
--- a/client/components/Home.js
+++ b/client/components/Home.js
@@ -1,54 +1,90 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Accordion from 'react-bootstrap/Accordion';
 
 /**
  * COMPONENT
  */
 export const Home = () => {
-	return (
-		<div className="home-page">
-			<h3>Welcome to the Tennis Events Website!</h3>
-			<p>
-				The purpose of this site is to provide a google calendar of the listed
-				ATP and WTA Tour events as they are schedled.
-			</p>
+  const [info, setInfo] = useState({ tournaments: [], atpTop: [], wtaTop: [] });
 
-			<h4>Technologies Used:</h4>
+  useEffect(() => {
+    async function loadData() {
+      try {
+        const res = await fetch('/api/tennis/home');
+        const data = await res.json();
+        setInfo(data);
+      } catch (err) {
+        console.error(err);
+        setInfo({
+          tournaments: [{ id: 'none', name: 'No tournaments available' }],
+          atpTop: [{ id: 'none', name: 'No rankings available' }],
+          wtaTop: [{ id: 'none', name: 'No rankings available' }],
+        });
+      }
+    }
+    loadData();
+  }, []);
 
-                        <Accordion defaultActiveKey="0">
-                                <Accordion.Item eventKey="0">
-                                        <Accordion.Header as={'h6'}>Google Calendar API</Accordion.Header>
-                                        <Accordion.Body>
-                                                Adds tournaments directly to your Google Calendar
-                                        </Accordion.Body>
-                                </Accordion.Item>
-                                <Accordion.Item eventKey="1">
-                                        <Accordion.Header as={'h6'}>Nightmare.js</Accordion.Header>
-                                        <Accordion.Body>
-                                                Scrapes tournament information from the web
-                                        </Accordion.Body>
-                                </Accordion.Item>
-                                <Accordion.Item eventKey="2">
-                                        <Accordion.Header as={'h6'}>SQLite & Sequelize</Accordion.Header>
-                                        <Accordion.Body>
-                                                Stores scraped data using a lightweight SQL database
-                                        </Accordion.Body>
-                                </Accordion.Item>
-                                <Accordion.Item eventKey="3">
-                                        <Accordion.Header as={'h6'}>React-Bootstrap</Accordion.Header>
-                                        <Accordion.Body>
-                                                Provides responsive UI components
-                                        </Accordion.Body>
-                                </Accordion.Item>
-                                <Accordion.Item eventKey="4">
-                                        <Accordion.Header as={'h6'}>Netlify Identity & Neon</Accordion.Header>
-                                        <Accordion.Body>
-                                                Serverless functions use Netlify Identity for auth and Neon for persistent storage
-                                        </Accordion.Body>
-                                </Accordion.Item>
-                        </Accordion>
-                </div>
-        );
+  return (
+    <div className="home-page">
+      <h3>Welcome to the Tennis Events Website!</h3>
+      <p>
+        The purpose of this site is to provide a google calendar of the listed ATP and WTA Tour events as they are schedled.
+      </p>
+
+      <section>
+        <h4>Currently Playing Tournaments</h4>
+        <ul>
+          {info.tournaments.map((t) => (
+            <li key={t.id || t.name}>{t.name}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h4>ATP Top 10</h4>
+        <ol>
+          {info.atpTop.map((p) => (
+            <li key={p.id}>{p.position ? `#${p.position} ${p.name}` : p.name}</li>
+          ))}
+        </ol>
+      </section>
+
+      <section>
+        <h4>WTA Top 10</h4>
+        <ol>
+          {info.wtaTop.map((p) => (
+            <li key={p.id}>{p.position ? `#${p.position} ${p.name}` : p.name}</li>
+          ))}
+        </ol>
+      </section>
+
+      <h4>Technologies Used:</h4>
+
+      <Accordion defaultActiveKey="0">
+        <Accordion.Item eventKey="0">
+          <Accordion.Header as={'h6'}>Google Calendar API</Accordion.Header>
+          <Accordion.Body>Adds tournaments directly to your Google Calendar</Accordion.Body>
+        </Accordion.Item>
+        <Accordion.Item eventKey="1">
+          <Accordion.Header as={'h6'}>Nightmare.js</Accordion.Header>
+          <Accordion.Body>Scrapes tournament information from the web</Accordion.Body>
+        </Accordion.Item>
+        <Accordion.Item eventKey="2">
+          <Accordion.Header as={'h6'}>SQLite & Sequelize</Accordion.Header>
+          <Accordion.Body>Stores scraped data using a lightweight SQL database</Accordion.Body>
+        </Accordion.Item>
+        <Accordion.Item eventKey="3">
+          <Accordion.Header as={'h6'}>React-Bootstrap</Accordion.Header>
+          <Accordion.Body>Provides responsive UI components</Accordion.Body>
+        </Accordion.Item>
+        <Accordion.Item eventKey="4">
+          <Accordion.Header as={'h6'}>Netlify Identity & Neon</Accordion.Header>
+          <Accordion.Body>Serverless functions use Netlify Identity for auth and Neon for persistent storage</Accordion.Body>
+        </Accordion.Item>
+      </Accordion>
+    </div>
+  );
 };
 
 export default Home;

--- a/server/api/tennis.js
+++ b/server/api/tennis.js
@@ -1,5 +1,74 @@
 const router = require('express').Router()
 const axios = require('axios')
+const fs = require('fs')
+const path = require('path')
+
+const cachePath = path.join(__dirname, '..', 'cache', 'homeData.json')
+const API_HOST = 'tennis-api-atp-wta-itf.p.rapidapi.com'
+
+// Helper to fetch tournaments currently being played
+const fetchCurrentTournaments = async () => {
+  if (!process.env.RAPIDAPI_KEY) return []
+
+  try {
+    const year = new Date().getFullYear()
+    const headers = {
+      'x-rapidapi-key': process.env.RAPIDAPI_KEY,
+      'x-rapidapi-host': API_HOST,
+    }
+
+    const today = new Date()
+    const tours = ['atp', 'wta']
+    const results = []
+
+    await Promise.all(
+      tours.map(async (tour) => {
+        const url = `https://${API_HOST}/tennis/v2/${tour}/tournament/calendar/${year}`
+        const { data } = await axios.get(url, { headers })
+        const events = data?.data || []
+
+        events.forEach((evt) => {
+          const start = evt.date ? new Date(evt.date) : null
+          if (!start) return
+          const diffDays = Math.floor((today - start) / (1000 * 60 * 60 * 24))
+          if (diffDays >= 0 && diffDays <= 7) {
+            results.push({ id: evt.id, name: evt.name })
+          }
+        })
+      })
+    )
+
+    return results
+  } catch (err) {
+    console.error(err)
+    return []
+  }
+}
+
+// Helper to fetch top ranked players for a tour
+const fetchTopPlayers = async (tour) => {
+  if (!process.env.RAPIDAPI_KEY) return []
+
+  try {
+    const headers = {
+      'x-rapidapi-key': process.env.RAPIDAPI_KEY,
+      'x-rapidapi-host': API_HOST,
+    }
+
+    const url = `https://${API_HOST}/tennis/v2/${tour}/ranking/singles/`
+    const { data } = await axios.get(url, { headers })
+    const ranks = data?.data || []
+
+    return ranks.slice(0, 10).map((r) => ({
+      id: r.player?.id || r.id,
+      name: r.player?.name || r.name || r.full_name,
+      position: r.position,
+    }))
+  } catch (err) {
+    console.error(err)
+    return []
+  }
+}
 
 // Search tennis data via RapidAPI
 router.get('/search', async (req, res, next) => {
@@ -11,12 +80,64 @@ router.get('/search', async (req, res, next) => {
       params: { search: q || 'ABC' },
       headers: {
         'x-rapidapi-key': process.env.RAPIDAPI_KEY,
-        'x-rapidapi-host': 'tennis-api-atp-wta-itf.p.rapidapi.com',
+        'x-rapidapi-host': API_HOST,
       },
     }
 
     const { data } = await axios.request(options)
     res.json(data)
+  } catch (err) {
+    next(err)
+  }
+})
+
+// Return cached daily home page data
+router.get('/home', async (req, res, next) => {
+  try {
+    let cache = {
+      lastUpdated: 0,
+      tournaments: [],
+      atpTop: [],
+      wtaTop: [],
+    }
+
+    if (fs.existsSync(cachePath)) {
+      cache = JSON.parse(fs.readFileSync(cachePath))
+    }
+
+    const oneDay = 24 * 60 * 60 * 1000
+    const now = Date.now()
+
+    if (now - cache.lastUpdated > oneDay) {
+      const [tournaments, atpTop, wtaTop] = await Promise.all([
+        fetchCurrentTournaments(),
+        fetchTopPlayers('atp'),
+        fetchTopPlayers('wta'),
+      ])
+
+      if (tournaments.length || atpTop.length || wtaTop.length) {
+        cache = { lastUpdated: now, tournaments, atpTop, wtaTop }
+        fs.writeFileSync(cachePath, JSON.stringify(cache))
+      }
+    }
+
+    const response = {
+      ...cache,
+      tournaments:
+        cache.tournaments.length
+          ? cache.tournaments
+          : [{ id: 'none', name: 'No tournaments available' }],
+      atpTop:
+        cache.atpTop.length
+          ? cache.atpTop
+          : [{ id: 'none', name: 'No rankings available' }],
+      wtaTop:
+        cache.wtaTop.length
+          ? cache.wtaTop
+          : [{ id: 'none', name: 'No rankings available' }],
+    }
+
+    res.json(response)
   } catch (err) {
     next(err)
   }

--- a/server/cache/.gitignore
+++ b/server/cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- Guard tennis API calls with try/catch to avoid crashes
- Keep previous cache and send placeholder text when no tournament or ranking data is returned
- Provide client-side fallback so home page still renders when API calls fail

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1d4158d38832f842102b24e01bb90