### PR TITLE
feat: switch to Ultimate Tennis API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ After cloning to your machine run `npm install` to install needed dependencies.
 The app now uses SQLite for storage by default, so no PostgreSQL configuration is required.
 Running `npm run start:dev` will both start your server and build your client side files using webpack. After running, the app will immediately scrape for current tournaments.
 
-### RapidAPI Tennis Search
+### Ultimate Tennis API
 
-The server exposes a proxy endpoint to the [Tennis API – ATP WTA ITF](https://rapidapi.com/). Set your RapidAPI key in the environment variable `RAPIDAPI_KEY` before starting the server:
+The server now uses the [Ultimate Tennis API](https://rapidapi.com/cantagalloedoardo/api/ultimate-tennis1) via RapidAPI. Set your RapidAPI key in the environment variable `RAPIDAPI_KEY` before starting the server:
 
 ```bash
 RAPIDAPI_KEY=your_key npm start
 ```
 
-Then you can query the API via `/api/tennis/search?q=player` to search for players or tournaments. The key is read from `process.env` so it stays out of version control.
+Then you can query the API via `/api/tennis/search?q=player` to search for players. The key is read from `process.env` so it stays out of version control.
 
 ## Netlify Identity and Neon
 


### PR DESCRIPTION
## Summary
- switch tennis data source to Ultimate Tennis API
- proxy search through /v1/players
- refresh README with new API details

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b30290d264832fb5575835c1e1c805