### PR TITLE
Add auth routes with guarding and logout links

### DIFF
--- a/client/Routes.js
+++ b/client/Routes.js
@@ -1,26 +1,69 @@
-import React, { Component, Fragment } from 'react';
-import { withRouter, Route, Switch } from 'react-router-dom';
+import React, { Component } from 'react';
+import { withRouter, Route, Switch, Redirect } from 'react-router-dom';
+import { connect } from 'react-redux';
+import { me } from './store';
 import Calendar from './components/Calendar';
 import Home from './components/Home';
 import Next from './components/Next';
+import { Login, Signup } from './components/AuthForm';
 
 /**
  * COMPONENT
  */
 class Routes extends Component {
-	render() {
-		return (
-			<div>
-				<Switch>
-					<Route exact path="/" component={Home} />
-					<Route path="/calendar" component={Calendar} />
-					<Route path="/next" component={Next} />
-				</Switch>
-			</div>
-		);
-	}
+        componentDidMount() {
+                this.props.loadInitialData();
+        }
+
+        render() {
+                const { isLoggedIn } = this.props;
+
+                return (
+                        <div>
+                                <Switch>
+                                        <Route exact path="/" component={Home} />
+                                        <Route path="/login" component={Login} />
+                                        <Route path="/signup" component={Signup} />
+                                        <Route
+                                                path="/calendar"
+                                                render={() =>
+                                                        isLoggedIn ? (
+                                                                <Calendar />
+                                                        ) : (
+                                                                <Redirect to="/login" />
+                                                        )
+                                                }
+                                        />
+                                        <Route
+                                                path="/next"
+                                                render={() =>
+                                                        isLoggedIn ? (
+                                                                <Next />
+                                                        ) : (
+                                                                <Redirect to="/login" />
+                                                        )
+                                                }
+                                        />
+                                </Switch>
+                        </div>
+                );
+        }
 }
+
+const mapState = (state) => {
+        return {
+                isLoggedIn: !!state.auth.id,
+        };
+};
+
+const mapDispatch = (dispatch) => {
+        return {
+                loadInitialData() {
+                        dispatch(me());
+                },
+        };
+};
 
 // The `withRouter` wrapper makes sure that updates are not blocked
 // when the url changes
-export default withRouter(Routes);
+export default withRouter(connect(mapState, mapDispatch)(Routes));

--- a/client/components/AuthForm.js
+++ b/client/components/AuthForm.js
@@ -11,11 +11,19 @@ const AuthForm = props => {
   return (
     <div>
       <form onSubmit={handleSubmit} name={name}>
+        {name === 'signup' && (
+          <div>
+            <label htmlFor="fullName">
+              <small>Name</small>
+            </label>
+            <input name="fullName" type="text" />
+          </div>
+        )}
         <div>
-          <label htmlFor="username">
-            <small>Username</small>
+          <label htmlFor="email">
+            <small>Email</small>
           </label>
-          <input name="username" type="text" />
+          <input name="email" type="email" />
         </div>
         <div>
           <label htmlFor="password">
@@ -23,6 +31,14 @@ const AuthForm = props => {
           </label>
           <input name="password" type="password" />
         </div>
+        {name === 'signup' && (
+          <div>
+            <label htmlFor="phone">
+              <small>Phone</small>
+            </label>
+            <input name="phone" type="text" />
+          </div>
+        )}
         <div>
           <button type="submit">{displayName}</button>
         </div>
@@ -60,9 +76,15 @@ const mapDispatch = dispatch => {
     handleSubmit(evt) {
       evt.preventDefault()
       const formName = evt.target.name
-      const username = evt.target.username.value
-      const password = evt.target.password.value
-      dispatch(authenticate(username, password, formName))
+      const credentials = {
+        email: evt.target.email.value,
+        password: evt.target.password.value,
+      }
+      if (formName === 'signup') {
+        credentials.name = evt.target.fullName.value
+        if (evt.target.phone.value) credentials.phone = evt.target.phone.value
+      }
+      dispatch(authenticate(credentials, formName))
     }
   }
 }

--- a/client/components/Navbar.js
+++ b/client/components/Navbar.js
@@ -1,23 +1,59 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Navbar, Container, Nav } from 'react-bootstrap';
+import { connect } from 'react-redux';
+import { logout } from '../store';
 
-const Navibar = () => (
-	<div>
-		<Navbar bg="light" expand="lg" className='navbar'>
-			<Container>
-				<Navbar.Brand href="/">Tennis Events</Navbar.Brand>
-				<Navbar.Toggle aria-controls="basic-navbar-nav" />
-				<Navbar.Collapse id="basic-navbar-nav">
-					<Nav className="me-auto">
-						<Nav.Link as={Link} to="/">Home</Nav.Link>
-						<Nav.Link as={Link} to="/calendar">Calendar</Nav.Link>
-						<Nav.Link as={Link} to="/next">What's Next?</Nav.Link>
-					</Nav>
-				</Navbar.Collapse>
-			</Container>
-		</Navbar>
-	</div>
+const Navibar = ({ isLoggedIn, handleClick }) => (
+        <div>
+                <Navbar bg="light" expand="lg" className="navbar">
+                        <Container>
+                                <Navbar.Brand href="/">Tennis Events</Navbar.Brand>
+                                <Navbar.Toggle aria-controls="basic-navbar-nav" />
+                                <Navbar.Collapse id="basic-navbar-nav">
+                                        <Nav className="me-auto">
+                                                <Nav.Link as={Link} to="/">Home</Nav.Link>
+                                                {isLoggedIn && (
+                                                        <Nav.Link as={Link} to="/calendar">
+                                                                Calendar
+                                                        </Nav.Link>
+                                                )}
+                                                {isLoggedIn && (
+                                                        <Nav.Link as={Link} to="/next">
+                                                                What's Next?
+                                                        </Nav.Link>
+                                                )}
+                                                {isLoggedIn ? (
+                                                        <Nav.Link onClick={handleClick}>Logout</Nav.Link>
+                                                ) : (
+                                                        <>
+                                                                <Nav.Link as={Link} to="/login">
+                                                                        Login
+                                                                </Nav.Link>
+                                                                <Nav.Link as={Link} to="/signup">
+                                                                        Sign Up
+                                                                </Nav.Link>
+                                                        </>
+                                                )}
+                                        </Nav>
+                                </Navbar.Collapse>
+                        </Container>
+                </Navbar>
+        </div>
 );
 
-export default Navibar;
+const mapState = (state) => {
+        return {
+                isLoggedIn: !!state.auth.id,
+        };
+};
+
+const mapDispatch = (dispatch) => {
+        return {
+                handleClick() {
+                        dispatch(logout());
+                },
+        };
+};
+
+export default connect(mapState, mapDispatch)(Navibar);

--- a/client/store/auth.js
+++ b/client/store/auth.js
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import history from '../history'
+import history from '../history.js'
 
 const TOKEN = 'token'
 
@@ -28,13 +28,13 @@ export const me = () => async dispatch => {
   }
 }
 
-export const authenticate = (username, password, method) => async dispatch => {
+export const authenticate = (credentials, method) => async dispatch => {
   try {
-    const res = await axios.post(`/auth/${method}`, {username, password})
+    const res = await axios.post(`/auth/${method}`, credentials)
     window.localStorage.setItem(TOKEN, res.data.token)
     dispatch(me())
   } catch (authError) {
-    return dispatch(setAuth({error: authError}))
+    return dispatch(setAuth({ error: authError }))
   }
 }
 

--- a/client/store/auth.spec.js
+++ b/client/store/auth.spec.js
@@ -1,12 +1,12 @@
 /* global describe beforeEach afterEach it */
 
-import {expect} from 'chai'
-import {me, logout} from './auth'
-import axios from 'axios'
-import MockAdapter from 'axios-mock-adapter'
-import configureMockStore from 'redux-mock-store'
-import thunkMiddleware from 'redux-thunk'
-import history from '../history'
+const {expect} = require('chai')
+const {me, logout} = require('./auth.js')
+const axios = require('axios')
+const MockAdapter = require('axios-mock-adapter')
+const configureMockStore = require('redux-mock-store').default
+const thunkMiddleware = require('redux-thunk').default.default || require('redux-thunk').default
+const history = require('../history.js').default
 
 const middlewares = [thunkMiddleware]
 const mockStore = configureMockStore(middlewares)
@@ -51,7 +51,7 @@ describe('thunk creators', () => {
         }
       })
       it('eventually dispatches the SET_AUTH action', async () => {
-        const fakeUser = {username: 'Cody'}
+        const fakeUser = {email: 'cody@example.com'}
         mockAxios.onGet('/auth/me').replyOnce(200, fakeUser)
         await store.dispatch(me())
         const actions = store.getActions()
@@ -70,7 +70,7 @@ describe('thunk creators', () => {
         }
       })
       it('does not dispatch GET USER action', async () => {
-        const fakeUser = {username: 'Cody'}
+        const fakeUser = {email: 'cody@example.com'}
         mockAxios.onGet('/auth/me').replyOnce(200, fakeUser)
         await store.dispatch(me())
         const actions = store.getActions()

--- a/script/seed.js
+++ b/script/seed.js
@@ -12,8 +12,8 @@ async function seed() {
 
   // Creating Users
   const users = await Promise.all([
-    User.create({ username: 'cody', password: '123' }),
-    User.create({ username: 'murphy', password: '123' }),
+    User.create({ name: 'Cody', email: 'cody@example.com', password: '123' }),
+    User.create({ name: 'Murphy', email: 'murphy@example.com', password: '123', phone: '1234567890' }),
   ])
 
   console.log(`seeded ${users.length} users`)

--- a/server/api/users.js
+++ b/server/api/users.js
@@ -5,10 +5,8 @@ module.exports = router
 router.get('/', async (req, res, next) => {
   try {
     const users = await User.findAll({
-      // explicitly select only the id and username fields - even though
-      // users' passwords are encrypted, it won't help if we just
-      // send everything to anyone who asks!
-      attributes: ['id', 'username']
+      // explicitly select only non-sensitive fields
+      attributes: ['id', 'name', 'email', 'phone']
     })
     res.json(users)
   } catch (err) {

--- a/server/db/models/User.js
+++ b/server/db/models/User.js
@@ -7,14 +7,25 @@ const bcrypt = require('bcrypt');
 const SALT_ROUNDS = 5;
 
 const User = db.define('user', {
-  username: {
+  name: {
     type: Sequelize.STRING,
+    allowNull: false,
+  },
+  email: {
+    type: Sequelize.STRING,
+    allowNull: false,
     unique: true,
-    allowNull: false
+    validate: {
+      isEmail: true,
+    },
   },
   password: {
     type: Sequelize.STRING,
-  }
+    allowNull: false,
+  },
+  phone: {
+    type: Sequelize.STRING,
+  },
 })
 
 module.exports = User
@@ -34,10 +45,10 @@ User.prototype.generateToken = function() {
 /**
  * classMethods
  */
-User.authenticate = async function({ username, password }){
-    const user = await this.findOne({where: { username }})
+User.authenticate = async function({ email, password }){
+    const user = await this.findOne({ where: { email } })
     if (!user || !(await user.correctPassword(password))) {
-      const error = Error('Incorrect username/password');
+      const error = Error('Incorrect email/password');
       error.status = 401;
       throw error;
     }

--- a/server/db/models/User.spec.js
+++ b/server/db/models/User.spec.js
@@ -22,13 +22,14 @@ describe('User model', () => {
     describe('authenticate', () => {
       let user;
       beforeEach(async()=> user = await User.create({
-        username: 'lucy',
+        name: 'Lucy',
+        email: 'lucy@example.com',
         password: 'loo'
       }));
       describe('with correct credentials', ()=> {
         it('returns a token', async() => {
           const token = await User.authenticate({
-            username: 'lucy',
+            email: 'lucy@example.com',
             password: 'loo'
           });
           expect(token).to.be.ok;
@@ -39,7 +40,7 @@ describe('User model', () => {
 
           try {
             await User.authenticate({
-              username: 'lucy@gmail.com',
+              email: 'lucy@gmail.com',
               password: '123'
             });
             throw 'nooo';


### PR DESCRIPTION
## Summary
- add login and signup routes and route guards protecting calendar and next pages
- link login/signup and logout from navbar
- support user name, email, password, and optional phone with signup/login forms
- fix auth tests by using explicit `.js` imports and CommonJS syntax

## Testing
- `NODE_ENV=test JWT=a_secret npx mocha "./server/**/*.spec.js" "./client/**/*.spec.js" --require @babel/register`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b310cb0c5c832faad7a414bcfb7229