### PR TITLE
Guard process env usage in client history

### DIFF
--- a/client/history.js
+++ b/client/history.js
@@ -1,7 +1,11 @@
-import {createMemoryHistory, createBrowserHistory} from 'history'
+import { createMemoryHistory, createBrowserHistory } from 'history'
+
+// In a browser environment the global `process` object may be undefined.
+// Use a `typeof` guard so referencing environment variables doesn't throw.
+const env = typeof process !== 'undefined' ? process.env : {}
 
 const history =
-  process.env.NODE_ENV === 'test'
+  env.NODE_ENV === 'test'
     ? createMemoryHistory()
     : createBrowserHistory()
 

--- a/client/store/auth.js
+++ b/client/store/auth.js
@@ -1,14 +1,19 @@
 let StackClientApp
-if (process.env.NODE_ENV === 'test') {
+// In a browser environment the global `process` object is not defined. Using
+// `typeof` avoids a ReferenceError when bundlers don't polyfill `process`.
+const env = typeof process !== 'undefined' ? process.env : {}
+if (env.NODE_ENV === 'test') {
   StackClientApp = class {}
 } else {
   ;({ StackClientApp } = require('@stackframe/js'))
 }
 const history = require('../history.js').default
 
+// Use the safe `env` wrapper above so that referencing environment variables
+// doesn't throw when `process` is unavailable in the browser.
 let stack = new StackClientApp({
-  projectId: process.env.NEXT_PUBLIC_STACK_PROJECT_ID,
-  publishableClientKey: process.env.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY
+  projectId: env.NEXT_PUBLIC_STACK_PROJECT_ID,
+  publishableClientKey: env.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY
 })
 export const __setStackClient = client => {
   stack = client


### PR DESCRIPTION
## Summary
- avoid `process` reference errors in browsers by guarding `history` env access

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b31d716ffc832f93b284c27a2cac03